### PR TITLE
Collect the machine id as a server's info

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -14,6 +14,7 @@ type Servers map[string]*Server
 
 //Server represent a config of a server
 type Server struct {
+	Id               string           `yaml:"id"`
 	MacAddress       net.HardwareAddr `yaml:"macAddress"`
 	IPAddress        string           `yaml:"ipAddress"`
 	Installed        bool             `yaml:"installed"`


### PR DESCRIPTION
The machine id is unique between computers and will help differentiate the servers. Some servers may have two IPs or two MAC addresses, so this will help us get the real number of servers that we are connected to. This is a problem that was raised the other day and it's eliminated with the functionality in this commit. 

Note that I don't have a working virtual machine, so the code is untested. The compilation and the tests passed. 